### PR TITLE
Add Reputation Control Buttons configuration

### DIFF
--- a/src/emissary.ts
+++ b/src/emissary.ts
@@ -29,6 +29,7 @@ declare global {
         "emissary.factionReputationRange": { minimum: number; maximum: number };
         "emissary.individualReputation": any[]; // TODO: Type
         "emissary.factionReputationIncrement": FactionReputationIncrement[];
+        "emissary.factionReputationControls": any[]; //TODO: Type
     }
 
     interface SceneControls {

--- a/src/module/menus/reputationTracker/reputationTracker.ts
+++ b/src/module/menus/reputationTracker/reputationTracker.ts
@@ -114,8 +114,6 @@ class ReputationTracker extends HandlebarsApplicationMixin(ApplicationV2) {
                 individual: constructor.reputation.individual,
             };
 
-            if (!game.user) return {};
-
             const mergedContext = foundry.utils.mergeObject(context, {
                 tabs: ReputationTabs,
                 reputationData: reputationData,

--- a/src/module/menus/reputationTracker/tabs/reputationTabConstructor.ts
+++ b/src/module/menus/reputationTracker/tabs/reputationTabConstructor.ts
@@ -3,16 +3,19 @@ import { FactionReputation } from "./types.ts";
 
 export class ReputationTabConstructor {
     reputation = {
-        faction: game.settings
-            ? (game.settings.get(MODNAME, "factionReputation") as FactionReputation[])
-            : ([] as FactionReputation[]),
+        faction: {
+            settings: game.settings
+                ? (game.settings.get(MODNAME, "factionReputation") as FactionReputation[])
+                : ([] as FactionReputation[]),
+            controls: game.settings.get(MODNAME, "factionReputationControls"),
+        },
         individual: game.settings ? (game.settings.get("emissary", "individualReputation") as any[]) : [],
     };
 
     setFactionReputationLevels(): void {
         if (!game.settings) return;
         const repSettings = game.settings.get(MODNAME, "factionReputationIncrement");
-        for (const faction of this.reputation.faction) {
+        for (const faction of this.reputation.faction.settings) {
             for (const repLevel of repSettings) {
                 if (faction.repNumber <= repLevel.maximum && faction.repNumber >= repLevel.minimum) {
                     faction.repLevel = { label: repLevel.label, color: repLevel.color };

--- a/src/module/menus/settings/reputationSettingsMenu.ts
+++ b/src/module/menus/settings/reputationSettingsMenu.ts
@@ -71,13 +71,14 @@ class ReputationSettingsMenu extends HandlebarsApplicationMixin(AppV2) {
             }
         });
 
-        game.settings?.set(MODNAME, "factionReputationRange", obj.factionReputationRange);
-        game.settings?.set(MODNAME, "factionReputationIncrement", obj.factionReputationIncrement);
+        game.settings.set(MODNAME, "factionReputationRange", obj.factionReputationRange);
+        game.settings.set(MODNAME, "factionReputationIncrement", obj.factionReputationIncrement);
     }
 
     static getSettings(): SettingsMenuObject {
-        const factionReputationRange = game.settings?.get(MODNAME, "factionReputationRange");
-        const factionReputationIncrement = game.settings?.get(MODNAME, "factionReputationIncrement");
+        const factionReputationRange = game.settings.get(MODNAME, "factionReputationRange");
+        const factionReputationIncrement = game.settings.get(MODNAME, "factionReputationIncrement");
+        const factionReputationControls = game.settings.get(MODNAME, "factionReputationControls");
         return {
             notoriety: [],
             individual: [],
@@ -92,9 +93,18 @@ class ReputationSettingsMenu extends HandlebarsApplicationMixin(AppV2) {
                 {
                     settingName: "Reputation Increment",
                     hint: "Sets the increment for each reputation level.",
-                    type: "reputationIncrement",
+                    type: "settingsArray",
+                    subtype: "increment",
                     id: "factionReputationIncrement",
                     settingValue: factionReputationIncrement,
+                },
+                {
+                    settingName: "Reputation Controls",
+                    hint: "Sets the configuration for the reputation gain and loss buttons. Label represents the tooltip for the button. Icons can be found at https://fontawesome.com/. Only enter the classes without the <i> tags.",
+                    type: "settingsArray",
+                    subtype: "control",
+                    id: "factionReputationControls",
+                    settingValue: factionReputationControls,
                 },
             ],
         };
@@ -143,7 +153,6 @@ class ReputationSettingsMenu extends HandlebarsApplicationMixin(AppV2) {
         const settingsArray = subsettingTarget?.querySelector(".settings-array");
         const lastChild = settingsArray?.lastElementChild;
         if (!lastChild) return;
-        console.log(lastChild);
         settingsArray?.insertAdjacentHTML(
             "beforeend",
             await renderTemplate("modules/emissary/templates/menu/partials/reputationIncrement.hbs", {

--- a/src/module/menus/types.ts
+++ b/src/module/menus/types.ts
@@ -21,6 +21,7 @@ interface SettingsMenuSettingData {
     settingName: string;
     hint: string;
     type: string;
+    subtype?: string;
     id: string;
     settingValue: SettingValues;
 }

--- a/src/scripts/registerSettings.ts
+++ b/src/scripts/registerSettings.ts
@@ -49,13 +49,26 @@ export function registerSettings(): void {
         config: false,
         type: Array,
         default: [
-            { label: "furious", minimum: -50, maximum: -30, color: "#FF0000" },
-            { label: "angry", minimum: -29, maximum: -15, color: "#FF4500" },
-            { label: "upset", minimum: -14, maximum: -5, color: "#FFA500" },
-            { label: "neutral", minimum: -4, maximum: 4, color: "#FFFFFF" },
-            { label: "pleased", minimum: 5, maximum: 14, color: "#FFFF00" },
-            { label: "happy", minimum: 15, maximum: 29, color: "#9acd32" },
-            { label: "revered", minimum: 30, maximum: 50, color: "#008000" },
+            { label: "Furious", minimum: -50, maximum: -30, color: "#FF0000" },
+            { label: "Angry", minimum: -29, maximum: -15, color: "#FF4500" },
+            { label: "Upset", minimum: -14, maximum: -5, color: "#FFA500" },
+            { label: "Neutral", minimum: -4, maximum: 4, color: "#FFFFFF" },
+            { label: "Pleased", minimum: 5, maximum: 14, color: "#FFFF00" },
+            { label: "Happy", minimum: 15, maximum: 29, color: "#9acd32" },
+            { label: "Revered", minimum: 30, maximum: 50, color: "#008000" },
+        ],
+    });
+
+    game.settings.register(MODNAME, "factionReputationControls", {
+        name: "Faction Reputation Controls",
+        scope: "world",
+        config: false,
+        type: Array,
+        default: [
+            { label: "Terrible Impression", amount: -5, icon: "fa-regular fa-face-nose-steam" },
+            { label: "Poor Impression", amount: -2, icon: "fa-regular fa-face-angry" },
+            { label: "Good Impression", amount: 2, icon: "fa-regular fa-face-smile" },
+            { label: "Great Impression", amount: 5, icon: "fa-regular fa-face-smile-hearts" },
         ],
     });
 }

--- a/src/scripts/registerTemplates.ts
+++ b/src/scripts/registerTemplates.ts
@@ -13,6 +13,7 @@ export function registerTemplates(): void {
         "modules/emissary/templates/menu/partials/setting.hbs",
         "modules/emissary/templates/menu/partials/reputationRange.hbs",
         "modules/emissary/templates/menu/partials/reputationIncrement.hbs",
+        "modules/emissary/templates/menu/partials/reputationControls.hbs",
         "modules/emissary/templates/menu/partials/form-footer.hbs",
     ];
 

--- a/src/styles/menu/settingsMenu.scss
+++ b/src/styles/menu/settingsMenu.scss
@@ -45,7 +45,7 @@
                         flex-direction: column;
                     }
 
-                    .reputation-increment {
+                    .array-setting {
                         display: flex;
                         flex-direction: row;
                         justify-content: space-between;
@@ -67,20 +67,22 @@
                         margin-top: 10px;
                         flex-direction: column;
 
-                        .array-setting {
-                            margin-bottom: 3px;
-                        }
-
                         .specific-setting {
                             display: flex;
                             justify-content: right;
                             align-items: center;
 
                             input {
-                                width: 60px;
                                 text-align: right;
                                 margin-left: 2px;
+                                margin-right: 10px;
+                                flex-grow: 1;
+                                max-width: 120px;
                             }
+                        }
+
+                        .array-setting {
+                            margin-bottom: 3px;
                         }
 
                         .add-row-button {

--- a/static/templates/menu/partials/reputationControls.hbs
+++ b/static/templates/menu/partials/reputationControls.hbs
@@ -1,0 +1,17 @@
+<div class="array-setting reputation-controls" key="{{key}}" id="{{id}}">
+    <div class="specific-setting">
+        <label for="{{id}}-{{key}}-label">Label</label>:
+        <input name="{{id}}-{{key}}-label" type="text" value="{{this.label}}" required />
+    </div>
+    <div class="specific-setting">
+        <label for="{{id}}-{{key}}-amount">Amount</label>:
+        <input name="{{id}}-{{key}}-amount" type="number" value="{{this.amount}}" required />
+    </div>
+    <div class="specific-setting">
+        <label for="{{id}}-{{key}}-icon">Icon</label>:
+        <input name="{{id}}-{{key}}-icon" type="text" value="{{this.icon}}" required />
+    </div>
+    <button class="remove-row-button" type="button" data-action="removeRow" data-tooltip="Remove Row">
+        -
+    </button>
+</div>

--- a/static/templates/menu/partials/reputationIncrement.hbs
+++ b/static/templates/menu/partials/reputationIncrement.hbs
@@ -15,7 +15,7 @@
         <label for="{{id}}-{{key}}-color">Color</label>:
         <input name="{{id}}-{{key}}-color" type="color" value="{{this.color}}" required />
     </div>
-    <button class="remove-row-button" type="button" data-action="removeRow" data-tooltip="Remove Increment">
+    <button class="remove-row-button" type="button" data-action="removeRow" data-tooltip="Remove Row">
         -
     </button>
 </div>

--- a/static/templates/menu/partials/setting.hbs
+++ b/static/templates/menu/partials/setting.hbs
@@ -1,4 +1,4 @@
-<div class="setting{{#when type "eq" "reputationIncrement"}} vertical{{/when}}">
+<div class="setting{{#when type "eq" "settingsArray"}} vertical{{/when}}">
     <div class="info">
         <span class="title">
             {{settingName}}
@@ -21,17 +21,22 @@
             {{#when type "eq" "reputationRange"}}
                 {{>"modules/emissary/templates/menu/partials/reputationRange.hbs" this id=id}}
             {{/when}}
-            {{#when type "eq" "reputationIncrement"}}
+            {{#when type "eq" "settingsArray"}}
                 <div class="settings-array">
                     {{#each settingValue}}
-                        {{>"modules/emissary/templates/menu/partials/reputationIncrement.hbs" this id=../id}}
+                        {{#when ../subtype "eq" "increment"}}
+                            {{>"modules/emissary/templates/menu/partials/reputationIncrement.hbs" this id=../id}}
+                        {{/when}}
+                        {{#when ../subtype "eq" "control"}}
+                            {{>"modules/emissary/templates/menu/partials/reputationControls.hbs" this id=../id}}
+                        {{/when}}
                     {{/each}}
                 </div>
                 <button 
                     class="add-row-button" 
                     type="button" 
                     data-action="addRow" 
-                    data-tooltip="Add a new increment"
+                    data-tooltip="Add Row"
                 >
                     +
                 </button>

--- a/static/templates/reputation-tracker/faction.hbs
+++ b/static/templates/reputation-tracker/faction.hbs
@@ -1,6 +1,8 @@
 <section class="tab {{tab.cssClass}}" data-group="primary" data-tab="faction-reputation">
-    {{#each reputationData.faction}}
-        {{> "modules/emissary/templates/reputation-tracker/partials/faction-item.hbs"}}
-    {{/each}}
+    {{#with reputationData.faction as |faction|}}
+        {{#each settings}}
+            {{> "modules/emissary/templates/reputation-tracker/partials/faction-item.hbs" faction=faction}}
+        {{/each}}
+    {{/with}}
     <button class="{{#if isGM}}visible{{/if}}" id="add-faction" data-action="addFaction">Add Faction</button>
 </section>

--- a/static/templates/reputation-tracker/partials/faction-item.hbs
+++ b/static/templates/reputation-tracker/partials/faction-item.hbs
@@ -15,74 +15,16 @@
     </div>
     <div class="rollout">
         <span class="control-buttons">
-            <button
-                class="reputation-control"
-                id="major-disservice"
-                faction-uuid="{{id}}"
-                data-value="-5"
-                data-action="updateReputation"
-                data-tooltip="{{localize 'emissary.menu.reputationTracker.buttons.disservices.major'}}"
-            >
-                <i class="fa-regular fa-face-nose-steam"></i>
-            </button>
-            <button
-                class="reputation-control"
-                id="moderate-disservice"
-                faction-uuid="{{id}}"
-                data-value="-2"
-                data-action="updateReputation"
-                data-tooltip="{{localize 'emissary.menu.reputationTracker.buttons.disservices.moderate'}}"
-            >
-                <i class="fa-regular fa-face-angry"></i>
-            </button>
-            <button
-                class="reputation-control"
-                id="minor-disservice"
-                faction-uuid="{{id}}"
-                data-value="-1"
-                data-action="updateReputation"
-                data-tooltip="{{localize 'emissary.menu.reputationTracker.buttons.disservices.minor'}}"
-            >
-                <i class="fa-regular fa-face-sad-sweat"></i>
-            </button>
-            <button
-                class="reputation-control"
-                id="minor-favor"
-                faction-uuid="{{id}}"
-                data-value="1"
-                data-action="updateReputation"
-                data-tooltip="{{localize 'emissary.menu.reputationTracker.buttons.favors.minor'}}"
-            >
-                <i class="fa-regular fa-face-smile"></i>
-            </button>
-            <button
-                class="reputation-control"
-                id="moderate-favor"
-                faction-uuid="{{id}}"
-                data-value="2"
-                data-action="updateReputation"
-                data-tooltip="{{localize 'emissary.menu.reputationTracker.buttons.favors.moderate'}}"
-            >
-                <i class="fa-regular fa-face-grin"></i>
-            </button>
-            <button
-                class="reputation-control"
-                id="major-favor"
-                faction-uuid="{{id}}"
-                data-value="5"
-                data-action="updateReputation"
-                data-tooltip="{{localize 'emissary.menu.reputationTracker.buttons.favors.major'}}"
-            >
-                <i class="fa-regular fa-face-smile-hearts"></i>
-            </button>
-        </span>
-        <button
-            class="remove-faction"
-            data-action="deleteFaction"
-            faction-uuid="{{id}}"
-            data-tooltip="{{localize 'emissary.menu.reputationTracker.buttons.remove'}}"
-        >
-            <i class="fa-regular fa-trash"></i>
-        </button>
+            {{#each faction.controls}}
+                <button
+                    class="reputation-control"
+                    faction-uuid="{{../id}}"
+                    data-value="{{amount}}"
+                    data-action="updateReputation"
+                    data-tooltip="{{label}}"
+                >
+                    <i class="{{icon}}"></i>
+                </button>
+            {{/each}}
     </div>
 </div>


### PR DESCRIPTION
Officially being called Reputation Control Buttons now. This PR adds configuration for the control buttons and hooks them up to the reputation tracker. Resolves #3 