### PR TITLE
Stop rollouts from closing on rerender

### DIFF
--- a/src/module/menus/reputationTracker/reputationTracker.ts
+++ b/src/module/menus/reputationTracker/reputationTracker.ts
@@ -5,7 +5,10 @@ import { FactionReputation } from "./tabs/types.ts";
 import { DeepPartial } from "fvtt-types/utils";
 import { UUID } from "crypto";
 import type { ApplicationRenderOptions } from "node_modules/fvtt-types/src/foundry/client/applications/_types.d.mts";
-import type { ApplicationV2 as AV2 } from "node_modules/fvtt-types/src/foundry/client/applications/api/_module.d.mts";
+import type {
+    ApplicationV2 as AV2,
+    HandlebarsApplicationMixin as hbs,
+} from "node_modules/fvtt-types/src/foundry/client/applications/api/_module.d.mts";
 
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
@@ -36,6 +39,19 @@ class ReputationTracker extends HandlebarsApplicationMixin(ApplicationV2) {
         },
     };
 
+    protected override _preSyncPartState(
+        partId: string,
+        newElement: HTMLElement,
+        priorElement: HTMLElement,
+        state: hbs.PartState,
+    ): void {
+        const openRollouts = priorElement.querySelectorAll(".rollout.active");
+        for (const openRollout of openRollouts) {
+            newElement.querySelector(`#${openRollout.id}`)?.classList.add("active", "no-transition");
+        }
+        super._preSyncPartState(partId, newElement, priorElement, state);
+    }
+
     static addFaction(): void {
         new AddFactionMenu(this).render(true);
     }
@@ -64,6 +80,7 @@ class ReputationTracker extends HandlebarsApplicationMixin(ApplicationV2) {
             const target = e.target as HTMLDivElement;
             const rollout = target.getElementsByClassName("rollout") as HTMLCollectionOf<HTMLDivElement>;
             for (const r of rollout) {
+                if (r.classList.contains("no-transition")) r.classList.remove("no-transition");
                 r.classList.toggle("active");
             }
         }

--- a/src/styles/menu/settingsMenu.scss
+++ b/src/styles/menu/settingsMenu.scss
@@ -31,6 +31,13 @@
                     max-height: 0px;
                 }
 
+                &.no-transition {
+                    transition: none;
+                    transition-behavior: unset;
+                    @starting-style {
+                    }
+                }
+
                 .setting {
                     display: flex;
                     justify-content: space-between;

--- a/src/styles/reputation-tracker/reputationTracker.scss
+++ b/src/styles/reputation-tracker/reputationTracker.scss
@@ -75,6 +75,13 @@
                     opacity: 0;
                     max-height: 0px;
                 }
+
+                &.no-transition {
+                    transition: none;
+                    transition-behavior: unset;
+                    @starting-style {
+                    }
+                }
             }
         }
     }

--- a/static/templates/menu/partials/settings-preview.hbs
+++ b/static/templates/menu/partials/settings-preview.hbs
@@ -20,7 +20,7 @@
                     {{label}}
                 </span>
             </div>
-            <div class="rollout active">
+            <div class="rollout active" id="reputation-control-{{@index}}">
                 <span class="control-buttons">
                     {{#each controls}}
                         <button

--- a/static/templates/reputation-tracker/partials/faction-item.hbs
+++ b/static/templates/reputation-tracker/partials/faction-item.hbs
@@ -13,7 +13,7 @@
             {{repLevel.label}}
         </span>
     </div>
-    <div class="rollout">
+    <div class="rollout" id="rollout-{{id}}">
         <span class="control-buttons">
             {{#each faction.controls}}
                 <button


### PR DESCRIPTION
Stops rollouts from closing or flickering during application rerenders.

Resolves #14 